### PR TITLE
795-backward-ros

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,7 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 endif()
 
 find_package(ament_cmake REQUIRED)
+find_package(backward_ros REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(sensor_msgs REQUIRED)
 find_package(std_msgs REQUIRED)

--- a/package.xml
+++ b/package.xml
@@ -9,6 +9,7 @@
 
   <license>TODO</license>
   <buildtool_depend>ament_cmake</buildtool_depend>
+  <depend>backward_ros</depend>
   <build_depend>rclcpp</build_depend>
   <build_depend>sensor_msgs</build_depend>
   <build_depend>std_srvs</build_depend>


### PR DESCRIPTION
This PR adds the backward_ros dependency in support of the main PR, https://github.com/MuLTechnologies/robo_cart_marc5/pull/799.